### PR TITLE
Add dark mode support and Deck card dependencies

### DIFF
--- a/css/ncgantt.css
+++ b/css/ncgantt.css
@@ -16,13 +16,13 @@
     --gantt-grid-line: #eeeeee;
 
     /* STATE COLORS (Light Mode) */
-    --gantt-color-1: #9aa4af;
-    --gantt-color-2: #2f80ed;
-    --gantt-color-3: #27ae60;
+    --gantt-color-1: #56ccf2;
+    --gantt-color-2: #6c757d;
+    --gantt-color-3: #9b51e0;
     --gantt-color-4: #f2994a;
-    --gantt-color-5: #9b51e0;
-    --gantt-color-6: #6c757d;
-    --gantt-color-7: #56ccf2;
+    --gantt-color-5: #27ae60;    
+    --gantt-color-6: #2f80ed;
+    --gantt-color-7: #9aa4af;
     --gantt-color-8: #f2c94c;
     --gantt-color-9: #eb5757;
     --gantt-color-10: #219653;
@@ -44,17 +44,19 @@
 
         /* STATE COLORS (Dark Mode tuned for contrast) */
 
-        --gantt-color-1: #7f8c98;
-        --gantt-color-2: #4ea1ff;
-        --gantt-color-3: #35d07f;
+        
+        --gantt-color-1: #63d2ff;
+        --gantt-color-2: #8a939c;
+        --gantt-color-3: #bb86fc;
         --gantt-color-4: #ffb066;
-        --gantt-color-5: #bb86fc;
-        --gantt-color-6: #8a939c;
-        --gantt-color-7: #63d2ff;
+        --gantt-color-5: #35d07f;
+        --gantt-color-6: #4ea1ff;
+        --gantt-color-7: #7f8c98;
         --gantt-color-8: #f7d774;
         --gantt-color-9: #ff6b6b;
         --gantt-color-10: #3ddc97;
     }
+
 }
 
 

--- a/css/ncgantt.css
+++ b/css/ncgantt.css
@@ -14,18 +14,20 @@
     --gantt-popup-bg: #ffffff;
     --gantt-hr: #e9e9e9;
     --gantt-grid-line: #eeeeee;
-    
-    /* Palette Variables */
-    --gantt-color-1: #52ba52;
-    --gantt-color-2: #5ca5d7;
-    --gantt-color-3: #ff7f0e;
-    --gantt-color-4: #ad91c6;
-    --gantt-color-5: #8c564b;
-    --gantt-color-6: #e377c2;
-    --gantt-color-7: #7f7f7f;
-    --gantt-color-8: #bcbd22;
-    --gantt-color-9: #17becf;
+
+    /* STATE COLORS (Light Mode) */
+    --gantt-color-1: #9aa4af;
+    --gantt-color-2: #2f80ed;
+    --gantt-color-3: #27ae60;
+    --gantt-color-4: #f2994a;
+    --gantt-color-5: #9b51e0;
+    --gantt-color-6: #6c757d;
+    --gantt-color-7: #56ccf2;
+    --gantt-color-8: #f2c94c;
+    --gantt-color-9: #eb5757;
+    --gantt-color-10: #219653;
 }
+
 
 /* Dark Mode Overrides */
 @media (prefers-color-scheme: dark) {
@@ -34,17 +36,24 @@
         --gantt-container-bg: #1e1e1e;
         --gantt-status-bg: #2d2d2d;
         --gantt-text: #e0e0e0;
-        --gantt-text-muted: #cccccc;
+        --gantt-text-muted: #bdbdbd;
         --gantt-border: #444444;
         --gantt-popup-bg: #2d2d2d;
-        --gantt-hr: #444444;
+        --gantt-hr: #3a3a3a;
         --gantt-grid-line: #333333;
 
-        /* Muted Palette for Dark Mode */
-        --gantt-color-1: #2d662d;
-        --gantt-color-2: #3a6887;
-        --gantt-color-3: #a35209;
-        /* ... add others as needed ... */
+        /* STATE COLORS (Dark Mode tuned for contrast) */
+
+        --gantt-color-1: #7f8c98;
+        --gantt-color-2: #4ea1ff;
+        --gantt-color-3: #35d07f;
+        --gantt-color-4: #ffb066;
+        --gantt-color-5: #bb86fc;
+        --gantt-color-6: #8a939c;
+        --gantt-color-7: #63d2ff;
+        --gantt-color-8: #f7d774;
+        --gantt-color-9: #ff6b6b;
+        --gantt-color-10: #3ddc97;
     }
 }
 

--- a/css/ncgantt.css
+++ b/css/ncgantt.css
@@ -2,12 +2,59 @@
  * All styles are scoped to .app-ncgantt to prevent conflicts
  */
 
+
+ :root {
+    /* Light Mode Variables */
+    --gantt-bg: #ffffff;
+    --gantt-container-bg: #ffffff;
+    --gantt-status-bg: #f8f9fa;
+    --gantt-text: #222222;
+    --gantt-text-muted: #666666;
+    --gantt-border: #dddddd;
+    --gantt-popup-bg: #ffffff;
+    --gantt-hr: #e9e9e9;
+    --gantt-grid-line: #eeeeee;
+    
+    /* Palette Variables */
+    --gantt-color-1: #52ba52;
+    --gantt-color-2: #5ca5d7;
+    --gantt-color-3: #ff7f0e;
+    --gantt-color-4: #ad91c6;
+    --gantt-color-5: #8c564b;
+    --gantt-color-6: #e377c2;
+    --gantt-color-7: #7f7f7f;
+    --gantt-color-8: #bcbd22;
+    --gantt-color-9: #17becf;
+}
+
+/* Dark Mode Overrides */
+@media (prefers-color-scheme: dark) {
+    :root {
+        --gantt-bg: #1e1e1e;
+        --gantt-container-bg: #1e1e1e;
+        --gantt-status-bg: #2d2d2d;
+        --gantt-text: #e0e0e0;
+        --gantt-text-muted: #cccccc;
+        --gantt-border: #444444;
+        --gantt-popup-bg: #2d2d2d;
+        --gantt-hr: #444444;
+        --gantt-grid-line: #333333;
+
+        /* Muted Palette for Dark Mode */
+        --gantt-color-1: #2d662d;
+        --gantt-color-2: #3a6887;
+        --gantt-color-3: #a35209;
+        /* ... add others as needed ... */
+    }
+}
+
+
 .app-ncgantt {
     /* Main container */
     .gannt_container {
         max-width: 100%;
         margin: 0 3px;
-        background: white;
+        background: var(--gantt-bg);
         padding: 20px;
         padding-top: 5px;
         border-radius: 8px;
@@ -41,7 +88,7 @@
     /* Status section */
     .status-section {
         width: 95%;
-        background: #f8f9fa;
+        background: var(--gantt-status-bg);
         border-radius: 6px;
         margin-bottom: 0px;
         padding: 10px;
@@ -62,7 +109,7 @@
     .label {
         display: block;
         margin-bottom: 5px;
-        color: #666;
+        color: var(--gantt-text-muted);
         font-weight: bold;
         white-space: nowrap;
     }
@@ -75,7 +122,7 @@
 
     /* Status messages */
     .error {
-        background: #fee;
+        background: var(--gantt-bg);
         color: #c33;
         padding: 2px 8px;
         border-radius: 4px;
@@ -83,7 +130,7 @@
     }
 
     .success {
-        background: #efe;
+        background: var(--gantt-bg);
         color: #363;
         padding: 2px 8px;
         border-radius: 4px;
@@ -92,7 +139,7 @@
 
     .loading {
         text-align: center;
-        color: #666;
+        color: var(--gantt-text-muted);
         padding: 2px 8px;
         border-radius: 4px;
         height: 22px;
@@ -117,7 +164,7 @@
         width: 20px;
         height: 13px;
         border-radius: 4px;
-        border: 1px solid #ddd;
+        border: 1px solid var(--gantt-border);
         font-size: 9px;
         text-align: center;
     }
@@ -126,7 +173,7 @@
     .labels-section {
         margin-top: 5px;
         padding-top: 0px;
-        border-top: 2px solid #ddd;
+        border-top: 2px solid var(--gantt-border);
     }
 
     .labels-title {
@@ -235,7 +282,7 @@
     }
 
     .gantt-container .popup-wrapper hr {
-        border: 1px solid #e9e9e9;
+        border: 1px solid var(--gantt-hr);
     }
 
     .gantt-container .popup-wrapper .popup-top-line {
@@ -260,7 +307,7 @@
         cursor: pointer;
         user-select: none;
         background-image: unset;
-        background-color: white;
+        background-color: var(--gantt-popup-bg) ;
         padding: 1px 2px;
     }
 
@@ -309,7 +356,7 @@
             left: 5px !important;
             width: 92vw !important;
             height: 90vh !important;
-            background-color: white !important;
+            background-color: var(--gantt-popup-bg) !important;
             z-index: 9999 !important;
             overflow: auto !important;
             padding: 15px;
@@ -404,71 +451,5 @@
         .gantt-container {
             overflow: visible !important;
         }
-    }
-}
-
-@media (prefers-color-scheme: dark) {
-    .app-ncgantt .gannt_container {
-        background: #1e1e1e;
-    }
-    .app-ncgantt .status-section {
-        background: #2d2d2d;
-        color: #e0e0e0;
-    }
-    .app-ncgantt .label {
-        color: #ccc;
-    }
-    .app-ncgantt .error {
-        background: #522;
-        color: #f99;
-    }
-    .app-ncgantt .success {
-        background: #252;
-        color: #9f9;
-    }
-    .app-ncgantt .loading {
-        color: #ccc;
-    }
-    .app-ncgantt .color-box {
-        border: 1px solid #555;
-    }
-    .app-ncgantt .labels-section {
-        border-top: 2px solid #555;
-    }
-    .app-ncgantt .md_textarea {
-        border-color: #555;
-        background-color: #2d2d2d;
-        color: #e0e0e0;
-    }
-    .app-ncgantt .html-md-icon-toggle, 
-    .app-ncgantt .md-html-icon-toggle {
-        background-color: transparent;
-    }
-    .app-ncgantt .gantt-container .popup-wrapper hr {
-        border: 1px solid #444;
-    }
-    
-    /* Frappe Gantt Dark Mode Fixes */
-    .app-ncgantt .gantt .grid-background { fill: #1e1e1e; }
-    .app-ncgantt .gantt .tick, 
-    .app-ncgantt .gantt .grid-header, 
-    .app-ncgantt .gantt .grid-row { stroke: #444; }
-    .app-ncgantt .gantt .upper-text, 
-    .app-ncgantt .gantt .lower-text { fill: #e0e0e0; }
-    .app-ncgantt .gantt-container .popup-wrapper { background-color: #2d2d2d; color: #e0e0e0; }
-    .app-ncgantt .board-select, 
-    .app-ncgantt .import-export-select, 
-    .app-ncgantt .import-export-btn { 
-        background: #2d2d2d; 
-        color: #e0e0e0; 
-        border: 1px solid #444; 
-    }
-}
-
-/* Mobile specific dark mode override */
-@media (prefers-color-scheme: dark) and (max-width: 768px) {
-    .app-ncgantt .gantt-container .popup-wrapper {
-        background-color: #1e1e1e !important;
-        color: #e0e0e0 !important;
     }
 }

--- a/css/ncgantt.css
+++ b/css/ncgantt.css
@@ -406,3 +406,69 @@
         }
     }
 }
+
+@media (prefers-color-scheme: dark) {
+    .app-ncgantt .gannt_container {
+        background: #1e1e1e;
+    }
+    .app-ncgantt .status-section {
+        background: #2d2d2d;
+        color: #e0e0e0;
+    }
+    .app-ncgantt .label {
+        color: #ccc;
+    }
+    .app-ncgantt .error {
+        background: #522;
+        color: #f99;
+    }
+    .app-ncgantt .success {
+        background: #252;
+        color: #9f9;
+    }
+    .app-ncgantt .loading {
+        color: #ccc;
+    }
+    .app-ncgantt .color-box {
+        border: 1px solid #555;
+    }
+    .app-ncgantt .labels-section {
+        border-top: 2px solid #555;
+    }
+    .app-ncgantt .md_textarea {
+        border-color: #555;
+        background-color: #2d2d2d;
+        color: #e0e0e0;
+    }
+    .app-ncgantt .html-md-icon-toggle, 
+    .app-ncgantt .md-html-icon-toggle {
+        background-color: transparent;
+    }
+    .app-ncgantt .gantt-container .popup-wrapper hr {
+        border: 1px solid #444;
+    }
+    
+    /* Frappe Gantt Dark Mode Fixes */
+    .app-ncgantt .gantt .grid-background { fill: #1e1e1e; }
+    .app-ncgantt .gantt .tick, 
+    .app-ncgantt .gantt .grid-header, 
+    .app-ncgantt .gantt .grid-row { stroke: #444; }
+    .app-ncgantt .gantt .upper-text, 
+    .app-ncgantt .gantt .lower-text { fill: #e0e0e0; }
+    .app-ncgantt .gantt-container .popup-wrapper { background-color: #2d2d2d; color: #e0e0e0; }
+    .app-ncgantt .board-select, 
+    .app-ncgantt .import-export-select, 
+    .app-ncgantt .import-export-btn { 
+        background: #2d2d2d; 
+        color: #e0e0e0; 
+        border: 1px solid #444; 
+    }
+}
+
+/* Mobile specific dark mode override */
+@media (prefers-color-scheme: dark) and (max-width: 768px) {
+    .app-ncgantt .gantt-container .popup-wrapper {
+        background-color: #1e1e1e !important;
+        color: #e0e0e0 !important;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -126,6 +126,24 @@
 			}
 		}
 
+		@media (prefers-color-scheme: dark) {
+    		body {
+        		background-color: #121212;
+        		color: #e0e0e0;
+			}
+			.settings-container, .settings-form {
+				background: #1e1e1e;
+			}
+			.config-section h2 {
+				color: #ccc;
+			}
+			.form-content input, .form-content select {
+				border: 1px solid #444;
+				background: #2d2d2d;
+				color: #e0e0e0;
+			}
+		}
+
 	</style>
 
 </head>

--- a/js/ncgantt_NCGantt.js
+++ b/js/ncgantt_NCGantt.js
@@ -40,8 +40,9 @@ class NCGantt {
                 bar_height: 20,
             },
             colorPalette: [
-                '#52ba52', '#5ca5d7', '#ff7f0e', '#ad91c6',
-                '#8c564b', '#e377c2', '#7f7f7f', '#bcbd22', '#17becf'
+              'var(--gantt-color-1)', 'var(--gantt-color-2)', 'var(--gantt-color-3)',
+              'var(--gantt-color-4)', 'var(--gantt-color-5)', 'var(--gantt-color-6)',
+              'var(--gantt-color-7)', 'var(--gantt-color-8)', 'var(--gantt-color-9)'
             ],
             update_timer_interval: 2000,
             update_blocking_delay: 2100,
@@ -159,6 +160,12 @@ class NCGantt {
         return false;
     }
 
+    isDarkMode() {
+    // Detect Nextcloud dark mode or system preference
+    return document.documentElement.classList.contains('theme-dark') || 
+           window.matchMedia('(prefers-color-scheme: dark)').matches;
+}
+
     // Helper to get element within app scope
     getElement(selector) {
         const appContainer = document.querySelector('.app-ncgantt');
@@ -179,20 +186,26 @@ class NCGantt {
         return document.querySelectorAll(selector);
     }
 
-    // Environment setup
+    
     setupEnvironment() {
         const el = this.getElement('#settingsContainer');
         if (!el) return;
         
+        const isDark = this.isDarkMode();
+        // If icons are dark by default, apply a CSS filter to make them white in dark mode
+        const iconClass = isDark ? 'class="icon-invert"' : '';
+
         if (this.config.isNextcloud) {
             el.classList.add("hidden");
-            this.symbols.edit =    '<img src="../../custom_apps/ncgantt/img/pencil2.svg">';
-            this.symbols.confirm = '<img src="../../custom_apps/ncgantt/img/check-square-outlined.svg">';
-            this.symbols.close =   '<img src="../../custom_apps/ncgantt/img/close-outlined-cross.svg">';
+            // Use Nextcloud's native paths but add the invert class if needed
+            this.symbols.edit =    `<img ${iconClass} src="../../custom_apps/ncgantt/img/pencil2.svg">`;
+            this.symbols.confirm = `<img ${iconClass} src="../../custom_apps/ncgantt/img/check-square-outlined.svg">`;
+            this.symbols.close =   `<img ${iconClass} src="../../custom_apps/ncgantt/img/close-outlined-cross.svg">`;
         } else {
             el.classList.remove("hidden");
         }
     }
+
 
     // Event listener management with automatic cleanup tracking
     addEventListener(element, event, handler, options) {
@@ -273,6 +286,14 @@ class NCGantt {
         this.addEventListener(window, 'online', () => {
             this.state.isOnline = true;
             this.showSuccess("You are online");
+        });
+
+        // Listen for system theme changes
+        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+            this.setupEnvironment();
+            if (this.state.ganttChart) {
+                this.createGanttChart(); // Re-render to apply new variable colors
+            }
         });
     }
 

--- a/js/ncgantt_NCGantt.js
+++ b/js/ncgantt_NCGantt.js
@@ -335,6 +335,22 @@ class NCGantt {
         }
     }
 
+    extractDependencies(description) {
+        if (!description) return '';
+        
+        // Matches standard Nextcloud Deck card URLs
+        const regex = /card\/(\d+)/g;
+        let deps = new Set(); // Use a Set to prevent duplicate dependencies
+        let match;
+        
+        while ((match = regex.exec(description)) !== null) {
+            // Format must match the ID definition in createGanttChart: `card-${id}`
+            deps.add(`card-${match[1]}`);
+        }
+        
+        return Array.from(deps).join(', ');
+    }
+
     async _makeApiCallInternal(endpoint, method, body) {
         const apiVersion = 'v1.1';
         
@@ -937,7 +953,10 @@ class NCGantt {
                         progress: progress || 0,
                         color: this.stackColors[stack.id],
                         color_progress: '#cfcfcfa3',
-                        dependencies: '',
+                        
+                        // get dependencies
+                        dependencies: this.extractDependencies(card.description),
+                        
                         custom_class: `stack-${stack.id}`,
                         //stack: stack.title,  // not needed
                         description: description_safeHtml || '',


### PR DESCRIPTION
## Summary

This PR improves NCGantt’s visual integration with dark mode and adds support for rendering dependencies between Deck cards in the Gantt chart.

Changes include:

- Add CSS variables for light and dark Gantt colors
- Improve Gantt, popup, status, and settings styling in dark mode
- Invert bundled action icons when dark mode is active
- Re-render the Gantt chart when the system color scheme changes
- Parse Deck card links from card descriptions and use them as Frappe Gantt dependencies

## Dependency Format

Dependencies are detected from Deck card URLs in the card description. For example, a description containing a link with `card/123` creates a dependency on task `card-123`.

## Testing

- Checked JavaScript syntax with `node --check js/ncgantt_NCGantt.js`
- Manually reviewed the diff against `upstream/main`

## Screenshots


Dependency linking in a Deck card description:
<img width="901" height="372" alt="image" src="https://github.com/user-attachments/assets/a10433b6-790f-448a-bdf5-57618712060d" />

Rendered dependency in the card description:
<img width="892" height="731" alt="image" src="https://github.com/user-attachments/assets/8fd04372-73d5-45cc-923a-021a1e573647" />

Dark mode with dependency arrow in the Gantt chart:
<img width="1547" height="245" alt="image" src="https://github.com/user-attachments/assets/0f32f164-aefc-4827-832b-c963e0429bbf" />
